### PR TITLE
Use typo3/cms-core instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "namelesscoder/typo3-cms-multilevel-cache",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms": "^7.6|^8"
+        "typo3/cms-core": "^8|^9"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,7 +18,7 @@ $EM_CONF[$_EXTKEY] = array (
   'modify_tables' => '',
   'clearCacheOnLoad' => 0,
   'lockType' => '',
-  'version' => '1.0.0',
+  'version' => '1.1.0',
   'constraints' =>
   array (
     'depends' =>


### PR DESCRIPTION
This uses the subtree split package instead of the whole thing.

Also allows usage of v9.